### PR TITLE
Add support for multiple Batchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
   The configured action will receive the batched list of things sent to it until the
   timeout or limit has triggered the action.
+
+  To add items to the batcher call `Batcher.append(myitem)`
+

--- a/lib/batcher.ex
+++ b/lib/batcher.ex
@@ -2,8 +2,8 @@ defmodule Batcher do
   use GenServer
   require Logger
 
-  def start_link(args \\ [], _) do
-    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  def start_link(args \\ [], name \\ __MODULE__) do
+    GenServer.start_link(__MODULE__, args, name: name)
   end
 
   def init(opts) do

--- a/lib/batcher.ex
+++ b/lib/batcher.ex
@@ -12,33 +12,18 @@ defmodule Batcher do
     {:ok, %{state | timer: timer}}
   end
 
-  @doc "Same as `append/2` but defaults to __MODULE__ for `batcher`"
-  def append(command) do
-    append(__MODULE__, command)
-  end
-
   @doc "Appends an item to the `batcher` (pid or atom)"
-  def append(batcher, command) do
+  def append(command, batcher \\ __MODULE__) do
     GenServer.cast(batcher, {:append, command})
   end
 
-  @doc "Same as `perform/2` but defaults to __MODULE__ for `batcher`"
-  def perform(command) do
-    perform(__MODULE__, command)
-  end
-
   @doc "Applies the action immediately to the `command` by the `batcher`"
-  def perform(batcher, command) do
+  def perform(command, batcher \\ __MODULE__) do
     GenServer.call(batcher, {:perform, command})
   end
 
-  @doc "Same as `backlog/1` but defaults to __MODULE__ for `batcher`"
-  def backlog do
-    backlog(__MODULE__)
-  end
-
   @doc "Retrieves the items in the backlog of the `batcher`"
-  def backlog(batcher) do
+  def backlog(batcher \\ __MODULE__) do
     GenServer.call(batcher, :backlog)
   end
 

--- a/test/batcher_test.exs
+++ b/test/batcher_test.exs
@@ -9,7 +9,7 @@ defmodule BatcherTest do
   context "without batching" do
     before do
       test = self
-      Batcher.start_link([action: fn(backlog) -> send(test, {:backlog, backlog}) end], [])
+      Batcher.start_link([action: fn(backlog) -> send(test, {:backlog, backlog}) end])
 
       :ok
     end
@@ -25,7 +25,7 @@ defmodule BatcherTest do
   context "with timeout" do
     before do
       test = self
-      Batcher.start_link([timeout: 100, action: fn(backlog) -> send(test, {:backlog, backlog}) end], [])
+      Batcher.start_link([timeout: 100, action: fn(backlog) -> send(test, {:backlog, backlog}) end])
 
       :ok
     end
@@ -44,7 +44,7 @@ defmodule BatcherTest do
   context "with limit" do
     before do
       test = self
-      Batcher.start_link([limit: 10, action: fn(backlog) -> send(test, {:backlog, backlog}) end], [])
+      Batcher.start_link([limit: 10, action: fn(backlog) -> send(test, {:backlog, backlog}) end])
 
       :ok
     end
@@ -67,14 +67,16 @@ defmodule BatcherTest do
       test = self
       {:ok, pid} = GenServer.start_link(Batcher,
         [timeout: 100,
-        action: fn(backlog) -> send(test, {:backlog, backlog}) end], [])
+        action: fn(backlog) -> send(test, {:backlog, backlog}) end])
       {:ok, pid: pid}
     end
 
     it "applies timeout", context do
       GenServer.cast(context[:pid], {:append, BatcherTest.command(1)})
       GenServer.cast(context[:pid], {:append, BatcherTest.command(2)})
-      expect(GenServer.call(context[:pid], :backlog) |> Enum.count) |> to_eq 2
+
+      expect(GenServer.call(context[:pid], :backlog)
+      |> Enum.count) |> to_eq 2
 
       assert_receive {:backlog, backlog}, 200
       expect(backlog) |> to_eq [BatcherTest.command(1), BatcherTest.command(2)]
@@ -92,9 +94,11 @@ defmodule BatcherTest do
 
       GenServer.cast(context[:pid], {:append, BatcherTest.command(1)})
       GenServer.cast(context[:pid], {:append, BatcherTest.command(2)})
-      expect(GenServer.call(context[:pid], :backlog) |> Enum.count) |> to_eq 2
 
-      assert_receive {:backlog, backlog}, 200
+      expect(GenServer.call(context[:pid], :backlog)
+      |> Enum.count) |> to_eq 2
+
+      assert_receive {:backlog, _backlog}, 200
     end
   end
 
@@ -104,7 +108,7 @@ defmodule BatcherTest do
       {:ok, pid} = GenServer.start_link(Batcher,
         [limit: 2,
          timeout: 200,
-         action: fn(backlog) -> send(test, {:backlog, backlog}) end], [])
+         action: fn(backlog) -> send(test, {:backlog, backlog}) end])
       {:ok, pid: pid}
     end
 
@@ -115,6 +119,56 @@ defmodule BatcherTest do
 
       GenServer.cast(context[:pid], {:append, BatcherTest.command(3)})
       assert_receive {:backlog, _backlog}, 300 # triggered by timeout
+    end
+  end
+
+  context "Multiple Batchers" do
+    before :each do
+      test = self
+      {:ok, p_limit} = Batcher.start_link([limit: 2,
+        action: fn(backlog) -> send(test, {:limit, backlog}) end], :limit)
+      {:ok, p_timeout} = Batcher.start_link([timeout: 100,
+        action: fn(backlog) -> send(test, {:timeout, backlog}) end], :timeout)
+      {:ok, p_both} = Batcher.start_link([timeout: 10000, limit: 2,
+        action: fn(backlog) -> send(test, {:both, backlog}) end], :both)
+
+      {:ok, batchers: %{limit: p_limit, timeout: p_timeout, both: p_both}}
+    end
+
+    it "handles limit", context do
+      Batcher.append(BatcherTest.command(1), context[:batchers][:limit])
+
+      expect(Batcher.backlog(context[:batchers][:limit])
+      |> Enum.count) |> to_eq 1
+
+      Batcher.append(BatcherTest.command(2), context[:batchers][:limit])
+
+      expect(Batcher.backlog(context[:batchers][:limit])) |> to_eq []
+      assert_received {:limit, _backlog}
+    end
+
+    it "handles timeout", context do
+      Batcher.append(BatcherTest.command(1), context[:batchers][:timeout])
+      Batcher.append(BatcherTest.command(2), context[:batchers][:timeout])
+
+      expect(Batcher.backlog(context[:batchers][:timeout]))
+      |> to_eq [BatcherTest.command(1), BatcherTest.command(2)]
+
+      assert_receive {:timeout, _backlog}, 200
+    end
+
+    it "handles both", context do
+      Batcher.append(BatcherTest.command(1), context[:batchers][:limit])
+      Batcher.append(BatcherTest.command(2), context[:batchers][:limit])
+
+      Batcher.append(BatcherTest.command(3), context[:batchers][:both])
+      Batcher.append(BatcherTest.command(4), context[:batchers][:both])
+
+      Batcher.append(BatcherTest.command(5), context[:batchers][:timeout])
+
+      assert_receive {:limit, _backlog}, 100
+      assert_receive {:both, _backlog}, 100
+      assert_receive {:timeout, _backlog}, 200
     end
   end
 end


### PR DESCRIPTION
- Fix issues with send_after. It now sends messages to
  self instead of `__MODULE__`
- Update state with new timer on `:trigger`
- Add new optional argument (pid or atom) for batcher functions, defaults to `__MODULE__`
- Add some `@doc` tags
- Add tests and update README

Reason for the changes is that I need to use multiple Batchers. The tests didn't turn out very pretty, but each added case illustrates one different instance of when the timer was configured to send a message to `__MODULE__`.

I'm still learning Elixir so I'm not sure these changes are 100% solid.
